### PR TITLE
fix(pnet): upgrade pnet version to not break with last rust version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ description = " ICMP ping library for quickly sending and measuring batches of I
 readme = "README.md"
 
 [dependencies]
-pnet = "0.22.0"
-pnet_macros_support = "0.22.0"
+pnet = "0.23.0"
+pnet_macros_support = "0.23.0"
 env_logger = "0.5.13"
 log = "0.4.5"
 rand = "0.4"


### PR DESCRIPTION
Hi ! I'm trying to use your crate in a personal project but it seems that with pnet 0.22 it's broken. When I upgrade to 0.23 It's running :) My rust version is 1.39 on OS X (rustc 1.39.0 (4560ea788 2019-11-04))

Signed-off-by: Benjamin Coenen <5719034+bnjjj@users.noreply.github.com>