### PR TITLE
Check for ICMP Reply Type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,7 +237,8 @@ impl Pinger {
                             }
                         } else {
                             debug!(
-                                "ICMP type other than reply (0) received: {:?}",
+                                "ICMP type other than reply (0) received from {:?}: {:?}",
+                                addr,
                                 packet.get_icmp_type()
                             );
                         }
@@ -276,7 +277,8 @@ impl Pinger {
                             }
                         } else {
                             debug!(
-                                "ICMP type other than reply (129) received: {:?}",
+                                "ICMP type other than reply (129) received from {:?}: {:?}",
+                                addr,
                                 packet.get_icmpv6_type()
                             );
                         }

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -1,22 +1,21 @@
-use std::net::{IpAddr};
-use rand::random;
-use pnet::packet::icmp::{IcmpTypes};
-use pnet::transport::TransportSender;
-use pnet::packet::icmp::{echo_request};
+use pnet::packet::icmp::echo_request;
+use pnet::packet::icmp::IcmpTypes;
 use pnet::packet::icmpv6::{Icmpv6Types, MutableIcmpv6Packet};
+use pnet::packet::Packet;
+use pnet::transport::TransportSender;
 use pnet::util;
 use pnet_macros_support::types::*;
-use pnet::packet::Packet;
-use std::time::{Duration, Instant};
+use rand::random;
 use std::collections::BTreeMap;
-use std::sync::mpsc::{ Sender, Receiver};
+use std::net::IpAddr;
+use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{Arc, Mutex, RwLock};
-use ::PingResult;
+use std::time::{Duration, Instant};
+use PingResult;
 
 fn send_echo(tx: &mut TransportSender, addr: IpAddr) -> Result<usize, std::io::Error> {
     // Allocate enough space for a new packet
     let mut vec: Vec<u8> = vec![0; 16];
-
 
     // Use echo_request so we can set the identifier and sequence number
     let mut echo_packet = echo_request::MutableEchoRequestPacket::new(&mut vec[..]).unwrap();
@@ -34,7 +33,6 @@ fn send_echov6(tx: &mut TransportSender, addr: IpAddr) -> Result<usize, std::io:
     // Allocate enough space for a new packet
     let mut vec: Vec<u8> = vec![0; 16];
 
-
     // Use echo_request so we can set the identifier and sequence number
     let mut echo_packet = MutableIcmpv6Packet::new(&mut vec[..]).unwrap();
     echo_packet.set_icmpv6_type(Icmpv6Types::EchoRequest);
@@ -45,87 +43,91 @@ fn send_echov6(tx: &mut TransportSender, addr: IpAddr) -> Result<usize, std::io:
     tx.send_to(echo_packet, addr)
 }
 
-pub fn send_pings(timer: Arc<RwLock<Instant>>,
-          stop: Arc<Mutex<bool>>,
-          results_sender: Sender<PingResult>,
-          thread_rx: Arc<Mutex<Receiver<PingResult>>>,
-          tx: Arc<Mutex<TransportSender>>,
-          txv6: Arc<Mutex<TransportSender>>,
-          addrs: Arc<Mutex<BTreeMap<IpAddr, bool>>>,
-          max_rtt: Arc<Duration>,
-      ) {
-      loop {
-          for (addr, seen) in addrs.lock().unwrap().iter_mut() {
-              match if addr.is_ipv4() {
-                  send_echo(&mut tx.lock().unwrap(), *addr)
-              } else if addr.is_ipv6() {
-                  send_echov6(&mut txv6.lock().unwrap(), *addr)
-              } else {
-                  Ok(0)
-              } {
-                  Err(e) => error!("Failed to send ping to {:?}: {}", *addr, e),
-                  _ => {}
-              }
-              *seen = false;
-          }
-          {
-              // start the timer
-              let mut timer = timer.write().unwrap();
-              *timer = Instant::now();
-          }
-          loop {
-              // use recv_timeout so we don't cause a CPU to needlessly spin
-              match thread_rx.lock().unwrap().recv_timeout(Duration::from_millis(100)) {
-                  Ok(result) => {
-                      match result {
-                          PingResult::Receive{addr, rtt: _} => {
-                              // Update the address to the ping response being received
-                              if let Some(seen) = addrs.lock().unwrap().get_mut(&addr) {
-                                  *seen = true;
-                                  // Send the ping result over the client channel
-                                  match results_sender.send(result) {
-                                      Ok(_) => {},
-                                      Err(e) => {
-                                          if !*stop.lock().unwrap() {
-                                              error!("Error sending ping result on channel: {}", e)
-                                          }
-                                      }
-                                  }
-                              }
-                          }
-                          _ => {}
-                      }
-                  },
-                  Err(_) => {
-                      // Check we haven't exceeded the max rtt
-                      let start_time = timer.read().unwrap();
-                      if Instant::now().duration_since(*start_time) > *max_rtt {
-                          break
-                      }
-                  }
-              }
-          }
-          // check for addresses which haven't replied
-          for (addr, seen) in addrs.lock().unwrap().iter() {
-              if *seen == false {
-                  // Send the ping Idle over the client channel
-                  match results_sender.send(PingResult::Idle{addr: *addr}) {
-                      Ok(_) => {},
-                      Err(e) => {
-                          if !*stop.lock().unwrap() {
-                              error!("Error sending ping Idle result on channel: {}", e)
-                          }
-                      }
-                  }
-              }
-          }
-          // check if we've received the stop signal
-          if *stop.lock().unwrap() {
-              return
-          }
-      }
-  }
-
+pub fn send_pings(
+    timer: Arc<RwLock<Instant>>,
+    stop: Arc<Mutex<bool>>,
+    results_sender: Sender<PingResult>,
+    thread_rx: Arc<Mutex<Receiver<PingResult>>>,
+    tx: Arc<Mutex<TransportSender>>,
+    txv6: Arc<Mutex<TransportSender>>,
+    addrs: Arc<Mutex<BTreeMap<IpAddr, bool>>>,
+    max_rtt: Arc<Duration>,
+) {
+    loop {
+        for (addr, seen) in addrs.lock().unwrap().iter_mut() {
+            match if addr.is_ipv4() {
+                send_echo(&mut tx.lock().unwrap(), *addr)
+            } else if addr.is_ipv6() {
+                send_echov6(&mut txv6.lock().unwrap(), *addr)
+            } else {
+                Ok(0)
+            } {
+                Err(e) => error!("Failed to send ping to {:?}: {}", *addr, e),
+                _ => {}
+            }
+            *seen = false;
+        }
+        {
+            // start the timer
+            let mut timer = timer.write().unwrap();
+            *timer = Instant::now();
+        }
+        loop {
+            // use recv_timeout so we don't cause a CPU to needlessly spin
+            match thread_rx
+                .lock()
+                .unwrap()
+                .recv_timeout(Duration::from_millis(100))
+            {
+                Ok(result) => {
+                    match result {
+                        PingResult::Receive { addr, rtt: _ } => {
+                            // Update the address to the ping response being received
+                            if let Some(seen) = addrs.lock().unwrap().get_mut(&addr) {
+                                *seen = true;
+                                // Send the ping result over the client channel
+                                match results_sender.send(result) {
+                                    Ok(_) => {}
+                                    Err(e) => {
+                                        if !*stop.lock().unwrap() {
+                                            error!("Error sending ping result on channel: {}", e)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                Err(_) => {
+                    // Check we haven't exceeded the max rtt
+                    let start_time = timer.read().unwrap();
+                    if Instant::now().duration_since(*start_time) > *max_rtt {
+                        break;
+                    }
+                }
+            }
+        }
+        // check for addresses which haven't replied
+        for (addr, seen) in addrs.lock().unwrap().iter() {
+            if *seen == false {
+                // Send the ping Idle over the client channel
+                match results_sender.send(PingResult::Idle { addr: *addr }) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        if !*stop.lock().unwrap() {
+                            error!("Error sending ping Idle result on channel: {}", e)
+                        }
+                    }
+                }
+            }
+        }
+        // check if we've received the stop signal
+        if *stop.lock().unwrap() {
+            return;
+        }
+    }
+}
 
 fn icmp_checksum(packet: &echo_request::MutableEchoRequestPacket) -> u16be {
     util::checksum(packet.packet(), 1)


### PR DESCRIPTION
As per RFC, replies to ICMP echo requests can be answered in ways that don't signal success, e.g. when a router replies with a type 3 (destination unreachable) - which has been so far accepted as a valid reply.
This changes the behavior towards what I would consider a more expected behavior, only accepting ICMP Echo Reply packets.

I also ran a `cargo fmt` but threw that into a separate commit for easier readability.