### PR TITLE
Add a basic CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+---
+name: Rust CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo check --all-targets
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo fmt --all -- --check
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --profile test --tests
+      - run: sudo -E `which cargo` test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ homepage = "https://github.com/bparli/fastping-rs"
 repository = "https://github.com/bparli/fastping-rs"
 description = " ICMP ping library for quickly sending and measuring batches of ICMP ECHO REQUEST packets."
 readme = "README.md"
+edition = "2021"
 
 [dependencies]
 pnet = "0.34"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,9 +419,6 @@ mod tests {
                                     assert!(false)
                                 }
                             }
-                            _ => {
-                                assert!(false)
-                            }
                         },
                         Err(_) => assert!(false),
                     }

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -1,3 +1,4 @@
+use crate::PingResult;
 use pnet::packet::Packet;
 use pnet::packet::{icmp, icmpv6};
 use pnet::transport::TransportSender;
@@ -8,7 +9,6 @@ use std::net::IpAddr;
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
-use PingResult;
 
 pub struct Ping {
     addr: IpAddr,


### PR DESCRIPTION
A simple `cargo check`, `cargo fmt --all -- --check`, and `cargo test`, run on each commit to main and any PR.

Also specifies Rust edition 2021 to bring code up to modern spec.