### PR TITLE
Update the API to be more resilient

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ fn main() {
         Err(e) => panic!("Error creating pinger: {}", e),
     };
 
-    pinger.add_ipaddr("8.8.8.8");
-    pinger.add_ipaddr("1.1.1.1");
-    pinger.add_ipaddr("7.7.7.7");
-    pinger.add_ipaddr("2001:4860:4860::8888");
+    pinger.add_ipaddr("8.8.8.8".parse().unwrap());
+    pinger.add_ipaddr("1.1.1.1".parse().unwrap());
+    pinger.add_ipaddr("7.7.7.7".parse().unwrap());
+    pinger.add_ipaddr("2001:4860:4860::8888".parse().unwrap());
     pinger.run_pinger();
 
     loop {

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ fn main() {
 Note a Pinger is initialized with two arguments: the maximum round trip time before an address is considered "idle" (2 seconds by default) and the size of the ping data packet (16 bytes by default).
 To explicitly set these values Pinger would be initialized like so:
 ```rust
-Pinger::new(Some(3000 as u64), Some(24 as usize))
+Pinger::new(Some(Duration::from_millis(3000)), Some(24 as usize))
 ```
 
 The public functions `stop_pinger()` to stop the continuous pinger and `ping_once()` to only run one round of pinging are also available.

--- a/examples/ping.rs
+++ b/examples/ping.rs
@@ -3,20 +3,22 @@ extern crate pretty_env_logger;
 #[macro_use]
 extern crate log;
 
+use std::error::Error;
+
 use fastping_rs::PingResult::{Idle, Receive};
 use fastping_rs::Pinger;
 
-fn main() {
+fn main() -> Result<(), Box<dyn Error>> {
     pretty_env_logger::init();
     let (pinger, results) = match Pinger::new(None, Some(64)) {
         Ok((pinger, results)) => (pinger, results),
         Err(e) => panic!("Error creating pinger: {}", e),
     };
 
-    pinger.add_ipaddr("8.8.8.8");
-    pinger.add_ipaddr("1.1.1.1");
-    pinger.add_ipaddr("7.7.7.7");
-    pinger.add_ipaddr("2001:4860:4860::8888");
+    pinger.add_ipaddr("8.8.8.8".parse()?);
+    pinger.add_ipaddr("1.1.1.1".parse()?);
+    pinger.add_ipaddr("7.7.7.7".parse()?);
+    pinger.add_ipaddr("2001:4860:4860::8888".parse()?);
     pinger.run_pinger();
 
     loop {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,28 @@
+/// Errors that can be returned by the API
+#[derive(Debug)]
+pub enum Error {
+    /// Networking problems, source will be a std::io::Error
+    NetworkError { source: std::io::Error },
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NetworkError { source } => write!(f, "Network error: {}", source),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::NetworkError { source } => Some(source),
+        }
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Error {
+        Self::NetworkError { source: e }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,7 @@ pub struct Pinger {
 
 impl Pinger {
     // initialize the pinger and start the icmp and icmpv6 listeners
-    pub fn new(max_rtt: Option<Duration>, _size: Option<usize>) -> NewPingerResult {
+    pub fn new(max_rtt: Option<Duration>, size: Option<usize>) -> NewPingerResult {
         let targets = BTreeMap::new();
         let (sender, receiver) = channel();
 
@@ -93,10 +93,10 @@ impl Pinger {
 
         let (thread_tx, thread_rx) = channel();
 
-        let mut pinger = Pinger {
+        let pinger = Pinger {
             max_rtt: Arc::new(max_rtt.unwrap_or(Duration::from_millis(2000))),
             targets: Arc::new(Mutex::new(targets)),
-            size: _size.unwrap_or(16),
+            size: size.unwrap_or(16),
             results_sender: sender,
             tx: Arc::new(Mutex::new(tx)),
             rx: Arc::new(Mutex::new(rx)),
@@ -107,9 +107,6 @@ impl Pinger {
             timer: Arc::new(RwLock::new(Instant::now())),
             stop: Arc::new(Mutex::new(false)),
         };
-        if let Some(size_value) = _size {
-            pinger.size = size_value;
-        }
 
         pinger.start_listener();
         Ok((pinger, receiver))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,32 +113,16 @@ impl Pinger {
     }
 
     // add either an ipv4 or ipv6 target address for pinging
-    pub fn add_ipaddr(&self, ipaddr: &str) {
-        let addr = ipaddr.parse::<IpAddr>();
-        match addr {
-            Ok(valid_addr) => {
-                debug!("Address added {}", valid_addr);
-                let new_ping = Ping::new(valid_addr);
-                self.targets.lock().unwrap().insert(valid_addr, new_ping);
-            }
-            Err(e) => {
-                error!("Error adding ip address {}. Error: {}", ipaddr, e);
-            }
-        };
+    pub fn add_ipaddr(&self, addr: IpAddr) {
+        debug!("Address added {}", addr);
+        let new_ping = Ping::new(addr);
+        self.targets.lock().unwrap().insert(addr, new_ping);
     }
 
     // remove a previously added ipv4 or ipv6 target address
-    pub fn remove_ipaddr(&self, ipaddr: &str) {
-        let addr = ipaddr.parse::<IpAddr>();
-        match addr {
-            Ok(valid_addr) => {
-                debug!("Address removed {}", valid_addr);
-                self.targets.lock().unwrap().remove(&valid_addr);
-            }
-            Err(e) => {
-                error!("Error removing ip address {}. Error: {}", ipaddr, e);
-            }
-        };
+    pub fn remove_ipaddr(&self, addr: IpAddr) {
+        debug!("Address removed {}", addr);
+        self.targets.lock().unwrap().remove(&addr);
     }
 
     // stop running the continous pinger
@@ -347,7 +331,7 @@ mod tests {
     fn test_add_remove_addrs() {
         match Pinger::new(None, None) {
             Ok((test_pinger, _)) => {
-                test_pinger.add_ipaddr("127.0.0.1");
+                test_pinger.add_ipaddr("127.0.0.1".parse().unwrap());
                 assert_eq!(test_pinger.targets.lock().unwrap().len(), 1);
                 assert!(test_pinger
                     .targets
@@ -355,7 +339,7 @@ mod tests {
                     .unwrap()
                     .contains_key(&"127.0.0.1".parse::<IpAddr>().unwrap()));
 
-                test_pinger.remove_ipaddr("127.0.0.1");
+                test_pinger.remove_ipaddr("127.0.0.1".parse().unwrap());
                 assert_eq!(test_pinger.targets.lock().unwrap().len(), 0);
                 assert_eq!(
                     test_pinger
@@ -395,7 +379,7 @@ mod tests {
             Ok((test_pinger, test_channel)) => {
                 let test_addrs = vec!["127.0.0.1", "7.7.7.7", "::1"];
                 for target in test_addrs.iter() {
-                    test_pinger.add_ipaddr(target);
+                    test_pinger.add_ipaddr(target.parse().unwrap());
                 }
                 test_pinger.ping_once();
                 for _ in test_addrs.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ use std::time::{Duration, Instant};
 
 // ping result type.  Idle represents pings that have not received a repsonse within the max_rtt.
 // Receive represents pings which have received a repsonse
+#[derive(Debug)]
 pub enum PingResult {
     Idle { addr: IpAddr },
     Receive { addr: IpAddr, rtt: Duration },

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -100,7 +100,7 @@ pub fn send_pings(
     tx: Arc<Mutex<TransportSender>>,
     txv6: Arc<Mutex<TransportSender>>,
     targets: Arc<Mutex<BTreeMap<IpAddr, Ping>>>,
-    max_rtt: Arc<Duration>,
+    max_rtt: &Duration,
 ) {
     loop {
         for (addr, ping) in targets.lock().unwrap().iter_mut() {

--- a/src/ping.rs
+++ b/src/ping.rs
@@ -10,6 +10,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 use PingResult;
 
+#[derive(Debug)]
 pub struct Ping {
     addr: IpAddr,
     identifier: u16,
@@ -17,6 +18,7 @@ pub struct Ping {
     pub seen: bool,
 }
 
+#[derive(Debug)]
 pub struct ReceivedPing {
     pub addr: IpAddr,
     pub identifier: u16,


### PR DESCRIPTION
 - Accept types that don't need parsing/interpreting where possible
   - No strings for IpAddr
   - Take Duration instead of u64 to clarify meaning
 - Add an Error enum, and return variants of it instead of String
 - Add documentation

Fixes #30 