### PR TITLE
Don't calculate checksum for ICMPv6

### DIFF
--- a/src/ping.rs
+++ b/src/ping.rs
@@ -85,8 +85,7 @@ fn send_echov6(
     echo_packet.set_identifier(ping.get_identifier());
     echo_packet.set_icmpv6_type(icmpv6::Icmpv6Types::EchoRequest);
 
-    let csum = util::checksum(echo_packet.packet(), 1);
-    echo_packet.set_checksum(csum);
+    // Note: ICMPv6 checksum always calculated by the kernel, see RFC 3542
 
     tx.send_to(echo_packet, ping.get_addr())
 }


### PR DESCRIPTION
The kernel will calculate checksums for ICMPv6 if the protocol for the socket is set to ICMPv6, see RFC 3542.

pnet does set the socket protocol to ICMPv6 appropriately: https://github.com/libpnet/libpnet/blob/main/pnet_transport/src/lib.rs#L112

I've verified this works correctly on Linux (5.15) and macOS (13.5).